### PR TITLE
Add zopen_get_version for lua

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -25,3 +25,8 @@ zopen_check_results()
   echo "totalTests:1"
   echo "expectedFailures:0"
 }
+
+zopen_get_version()
+{
+    ./src/lua -v 2>&1 | cut -f2 -d' '
+}


### PR DESCRIPTION
I can not get the version part from ./src/lua -v with grep/awk/cut/sed/... I am not 100% sure if redirects stderr to stdout is the right way to do it in this situation but it works.